### PR TITLE
Fix wrong ambient note between adjacent platforms

### DIFF
--- a/characters/player/player.tscn
+++ b/characters/player/player.tscn
@@ -273,6 +273,8 @@ _data = {
 [node name="Player" type="CharacterBody2D"]
 z_index = 1
 texture_filter = 1
+collision_layer = 2
+collision_mask = 3
 script = ExtResource("1_qb0pk")
 jump_note_player_scene = ExtResource("2_fw7sl")
 
@@ -311,7 +313,8 @@ libraries = {
 }
 
 [node name="TileDetectorArea" parent="." instance=ExtResource("4_cq6e0")]
-position = Vector2(0, 40)
+position = Vector2(0, 36)
+scale = Vector2(3, 1)
 
 [node name="KeyboardController" parent="." instance=ExtResource("5_7ussj")]
 

--- a/game_objects/ladders/ladder.tscn
+++ b/game_objects/ladders/ladder.tscn
@@ -27,6 +27,8 @@ region_rect = Rect2(0, 0, 48, 96)
 [node name="Area2D" type="Area2D" parent="Pivot"]
 unique_name_in_owner = true
 scale = Vector2(1, 2)
+collision_layer = 4
+collision_mask = 2
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="Pivot/Area2D"]
 position = Vector2(24, 24)
@@ -38,6 +40,8 @@ position = Vector2(0, 96)
 
 [node name="LowerInteraction" parent="BottomPivot" instance=ExtResource("3_4txev")]
 position = Vector2(24, -30)
+collision_layer = 4
+collision_mask = 2
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="BottomPivot/LowerInteraction"]
 shape = SubResource("RectangleShape2D_uvy5e")
@@ -50,6 +54,8 @@ unique_name_in_owner = true
 
 [node name="UpperInteraction" parent="TopPivot" instance=ExtResource("3_4txev")]
 position = Vector2(24, -18)
+collision_layer = 4
+collision_mask = 2
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="TopPivot/UpperInteraction"]
 shape = SubResource("RectangleShape2D_uvy5e")

--- a/game_objects/switch_blocks/switch_block.tscn
+++ b/game_objects/switch_blocks/switch_block.tscn
@@ -72,6 +72,7 @@ _data = {
 
 [node name="SwitchBlock" type="StaticBody2D"]
 modulate = Color(1, 0.407843, 0.337255, 1)
+collision_mask = 3
 script = ExtResource("1_22t1h")
 block_note_player_scene = ExtResource("2_32ohu")
 
@@ -81,6 +82,7 @@ shape = SubResource("RectangleShape2D_qwe2d")
 
 [node name="HitDetection" type="Area2D" parent="."]
 position = Vector2(24, 48)
+collision_mask = 3
 monitoring = false
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="HitDetection"]

--- a/game_objects/tile_detector_area.gd
+++ b/game_objects/tile_detector_area.gd
@@ -1,9 +1,10 @@
-extends Area2D
+extends Node2D
 
 signal tone_changed(tone: Globals.Tone)
 signal octave_changed(octave: int)
 
-func _on_body_entered(body: Node2D) -> void:
+
+func _update_overlapping_body(body: Node2D) -> void:
 	var platform: Platform = body as Platform
 	if platform:
 		tone_changed.emit(platform.tone)
@@ -13,3 +14,13 @@ func _on_body_entered(body: Node2D) -> void:
 		if switch_block:
 			tone_changed.emit(switch_block.tone)
 			octave_changed.emit(switch_block.octave)
+
+
+func _on_center_area_2d_body_entered(body: Node2D) -> void:
+	_update_overlapping_body(body)
+
+
+func _on_base_area_2d_body_entered(body: Node2D) -> void:
+	var overlapping_bodies = $BaseArea2D.get_overlapping_bodies()
+	if overlapping_bodies.size() == 1:
+		_update_overlapping_body(overlapping_bodies[0])

--- a/game_objects/tile_detector_area.tscn
+++ b/game_objects/tile_detector_area.tscn
@@ -1,14 +1,26 @@
-[gd_scene load_steps=3 format=3 uid="uid://7y3jaf7ow5yt"]
+[gd_scene load_steps=4 format=3 uid="uid://7y3jaf7ow5yt"]
 
 [ext_resource type="Script" path="res://game_objects/tile_detector_area.gd" id="1_3681d"]
 
-[sub_resource type="CircleShape2D" id="CircleShape2D_v2tak"]
-radius = 2.0
+[sub_resource type="SegmentShape2D" id="SegmentShape2D_7iu3d"]
+b = Vector2(0, 4)
 
-[node name="TileDetectorArea" type="Area2D"]
+[sub_resource type="SegmentShape2D" id="SegmentShape2D_7p3te"]
+a = Vector2(-5, 4)
+b = Vector2(5, 4)
+
+[node name="TileDetectorArea" type="Node2D"]
 script = ExtResource("1_3681d")
 
-[node name="CollisionShape2D" type="CollisionShape2D" parent="."]
-shape = SubResource("CircleShape2D_v2tak")
+[node name="CenterArea2D" type="Area2D" parent="."]
 
-[connection signal="body_entered" from="." to="." method="_on_body_entered"]
+[node name="CollisionShape2D" type="CollisionShape2D" parent="CenterArea2D"]
+shape = SubResource("SegmentShape2D_7iu3d")
+
+[node name="BaseArea2D" type="Area2D" parent="."]
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="BaseArea2D"]
+shape = SubResource("SegmentShape2D_7p3te")
+
+[connection signal="body_entered" from="CenterArea2D" to="." method="_on_center_area_2d_body_entered"]
+[connection signal="body_entered" from="BaseArea2D" to="." method="_on_base_area_2d_body_entered"]

--- a/levels/world.gd
+++ b/levels/world.gd
@@ -170,14 +170,16 @@ func _ready() -> void:
 
 func _on_player_current_tone_changed(tone: Globals.Tone) -> void:
 	player_tone = tone
-	_stop_ambient_note()
-	_start_ambient_note(player_tone, player_octave)
+	if $Player.is_on_floor():
+		_stop_ambient_note()
+		_start_ambient_note(player_tone, player_octave)
 
 
 func _on_player_current_octave_changed(octave: int) -> void:
 	player_octave = octave
-	_stop_ambient_note()
-	_start_ambient_note(player_tone, player_octave)
+	if $Player.is_on_floor():
+		_stop_ambient_note()
+		_start_ambient_note(player_tone, player_octave)
 
 func _on_player_on_floor_changed(value) -> void:
 	if value:

--- a/project.godot
+++ b/project.godot
@@ -123,6 +123,12 @@ in_game_menu={
 ]
 }
 
+[layer_names]
+
+2d_physics/layer_1="Environment"
+2d_physics/layer_2="Player"
+2d_physics/layer_3="Ladder"
+
 [physics]
 
 common/physics_ticks_per_second=120

--- a/tilesets/environment.tres
+++ b/tilesets/environment.tres
@@ -1140,6 +1140,7 @@ texture_region_size = Vector2i(48, 48)
 [resource]
 tile_size = Vector2i(48, 48)
 physics_layer_0/collision_layer = 1
+physics_layer_0/collision_mask = 3
 terrain_set_0/mode = 0
 terrain_set_0/terrain_0/name = "Platform"
 terrain_set_0/terrain_0/color = Color(0.501961, 0.901961, 0.25098, 1)


### PR DESCRIPTION
- Convert tile detector area `CenterArea2D` shape from sphere to vertical segment so that it precisely overlaps with only one platform
- Add a second area `BaseArea2D` in the tile detector that is wider than the previous one to detect bodies when the player is on an edge of a platform or a switch block. This area has detection priority over `CenterArea2D` unless it is overlapping more than 1 body (e.g. when player is standing on 2 adjacent platforms). In that case we check for the `CenterArea2D` overlap only.
- Adjust collision masks to avoid tile detector to detect player collisions
- Prevent playing ambient note before reaching top platform when climbing ladder: Verify that player is on floor when octave or tone change.